### PR TITLE
fixing sources.bib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+*.egg-info
+.idea/
+

--- a/lexibank_tuled.py
+++ b/lexibank_tuled.py
@@ -45,7 +45,8 @@ class Dataset(BaseDataset):
             )
 
     def cmd_makecldf(self, args):
-
+        from pybtex import errors
+        errors.strict = False
         args.writer.add_sources()
         args.writer["FormTable", "Segments"].separator = " + "
         args.writer["FormTable", "Segments"].datatype = Datatype.fromvalue(

--- a/raw/sources.bib
+++ b/raw/sources.bib
@@ -14007,7 +14007,7 @@ pages={215--228}
   author={Pease, Helen & Betts, Lavera},
   booktitle={Tupi Studies, I},
   volume={29},
-editor={Bendor, Samuel}
+editor={Bendor, Samuel},
   pages={1--14},
   year={1971},
   publisher={SIL}
@@ -15039,7 +15039,7 @@ editor={Arizcuren, Francisco O.},
     title = {{T}upían},
     booktitle = {The {I}ndigenous {L}anguages of {S}outh {A}merica},
     publisher = {de Gruyter},
-    address={Berlin}
+    address={Berlin},
     pages={495--574},
     year = {2012}
 }
@@ -15223,7 +15223,7 @@ editor={Arizcuren, Francisco O.},
 @mastersthesis{alves2008fonetica,
   title={Fonética e Fonologia da Língua Araweté: uma nova contribuição},
   author={Alves, Juliana Ferreira},
-school{Universidade de Brasília},
+school={Universidade de Brasília},
   year={2008},
 note={Unpublished master’s thesis}
 }


### PR DESCRIPTION
Here's what I needed to fix in `sources.bib` (and processing code) to get `lexibank.makecldf` to run. There's lots of duplicates in the bibliography, which presumably should be cleaned up rather than ignored by pybtex.